### PR TITLE
Only close workspace if all panes are empty

### DIFF
--- a/lib/close-after-last-tab.coffee
+++ b/lib/close-after-last-tab.coffee
@@ -1,7 +1,6 @@
 module.exports =
 
   activate: ->
-    atom.workspaceView.on 'pane-container:active-pane-item-changed', ->
-      if not atom.workspace.getActivePane().getActiveItem()
+    atom.workspaceView.on 'pane:item-removed', ->
+      if atom.workspace.getEditors().length is 0
         atom.close()
-

--- a/package.json
+++ b/package.json
@@ -13,10 +13,15 @@
     {
       "name": "Dan Zimmerman",
       "url": "http://danzimm.com"
+    },
+    {
+      "name": "Jason Tokoph",
+      "url": "http://jasontokoph.com",
+      "email": "jason@tokoph.net"
     }
   ],
   "activationEvents": [
-    "pane-container:active-pane-item-changed"
+    "pane:item-removed"
   ],
   "engines": {
     "atom": ">0.50.0"


### PR DESCRIPTION
Before this change, closing the last file in pane A will close the workspace even if a split pane (Pane B) still had open files. This change makes sure all editor windows in the workspace are closed regardless of how many panes there are.
