### PR TITLE
Add configuration option to close the current window with or after the last tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # Close After Last Tab
 
-In Atom, when all of your tabs are closed, the window does not close. This is typical UX expected(and delivered) from *most* text editors. This resolves the issue.
+In Atom, when all of your tabs are closed, the window does not close. This is typical UX expected (and delivered) from *most* text editors. This resolves the issue.
+
+## Configuration options
+
+You can use the `close-after-last-tab.closeWindowTogetherWithLastTab` [configuration option](https://atom.io/docs/latest/customizing-atom#advanced-configuration) to configure whether the window is closed with or after the last tab is closed:
+
+```coffee
+# config.cson
+
+'close-after-last-tab':
+  'closeWindowTogetherWithLastTab': true
+```
+
+You can also configure this option in _Atom > Preferences > Close After Last Tab_.
+
+If `closeWindowTogetherWithLastTab` is set to `false`, then Atom will close when `core:close` is triggered (e.g. with `cmd-w`) after the last tab has been closed. In other words, you need to press `cmd-w` again after the last tab has been closed.
+
+If `closeWindowTogetherWithLastTab` is set to `true`, then Atom will close when `core:close` is triggered to close the last tab. In other words, pressing `cmd-w` to close the last tab will also close the window.
+
+By default, `closeWindowTogetherWithLastTab` is set to `true`.

--- a/lib/close-after-last-tab.coffee
+++ b/lib/close-after-last-tab.coffee
@@ -1,6 +1,23 @@
+hadNoPanes = false
+
 module.exports =
+  configDefaults:
+    closeWindowTogetherWithLastTab: true
 
   activate: ->
-    atom.workspaceView.on 'pane:item-removed', ->
-      if atom.workspace.getEditors().length is 0
+    hadNoPanes = atom.workspace.getEditors().length == 0
+
+    atom.workspaceView.on 'pane:item-removed', =>
+      if atom.workspace.getPanes().length == 1 and
+         atom.workspace.getPanes()[0].getItems().length == 0
+        if atom.config.get('close-after-last-tab.closeWindowTogetherWithLastTab')
+          hadNoPanes = true
+        else
+          process.nextTick => hadNoPanes = true
+
+    atom.workspaceView.on 'pane:item-added', =>
+      hadNoPanes = false
+
+    atom.workspaceView.on 'core:close', =>
+      if hadNoPanes
         atom.close()

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
       "name": "Jason Tokoph",
       "url": "http://jasontokoph.com",
       "email": "jason@tokoph.net"
+    },
+    {
+      "name": "Ivan Žužak",
+      "email": "izuzak@gmail.com"
     }
-  ],
-  "activationEvents": [
-    "pane:item-removed"
   ],
   "engines": {
     "atom": ">0.50.0"


### PR DESCRIPTION
Fixes https://github.com/JRHeaton/atom-close-after-last-tab/issues/2 and related to https://github.com/atom/atom/issues/863 and https://github.com/atom/atom/pull/2411.

This adds a configuration option which allows users to select whether the window will be closed with or after the last tab. By default, the option is set so that the window is closed with the last tab to match the current behavior.

Also, this changes the behavior of the package so that all tabs are counted, not just editor tabs. That makes sense to me and matches my expectations, but still wanted to point it out.

cc @JRHeaton @jingchan @joernhees
