### PR TITLE
Fix errors caused by deprecations in atom beta

### DIFF
--- a/lib/close-after-last-tab.coffee
+++ b/lib/close-after-last-tab.coffee
@@ -1,6 +1,6 @@
 module.exports =
 
   activate: ->
-    atom.workspaceView.on 'pane:item-removed', ->
-      if atom.workspace.getEditors().length is 0
+    atom.workspace.onDidDestroyPaneItem ->
+      if atom.workspace.getTextEditors().length is 0
         atom.close()


### PR DESCRIPTION
Remove deprecations causing errors in atom beta

- Workspace view is no longer available and each event has a separate call.
- Editors has been replaced with getTextEditors.

This fixes #7 